### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ from source:
 
 ```bash
 go get github.com/vito/booklit/cmd/booklit
+go install github.com/vito/booklit/cmd/booklit
 ```
 
 ## usage


### PR DESCRIPTION
`go get` deprecated in 1.18, must use `go install` to get the binary: https://go.dev/doc/go1.18#go-command