### PR TITLE
feat(baselit): optional class-based syntax highlighting

### DIFF
--- a/baselit/plugin.go
+++ b/baselit/plugin.go
@@ -20,6 +20,28 @@ func init() {
 	booklit.RegisterPlugin("baselit", NewPlugin)
 }
 
+// HighlightWithClasses controls how syntax highlighting emits color. When
+// false (the default) chroma writes inline style attributes on each token,
+// matching booklit's historical output. When true it emits chroma's CSS class
+// names instead, leaving color to a stylesheet the caller provides (e.g. via
+// chroma's html.Formatter.WriteCSS, or a hand-written palette). This lets a
+// site theme code blocks — for instance switching palettes under
+// prefers-color-scheme — which inline styles cannot do.
+var HighlightWithClasses = false
+
+// highlightFormatter builds the chroma HTML formatter for the current
+// HighlightWithClasses setting. flow marks inline (non-block) code.
+func highlightFormatter(flow bool) *html.Formatter {
+	var opts []html.Option
+	if HighlightWithClasses {
+		opts = append(opts, html.WithClasses(true))
+	}
+	if flow {
+		opts = append(opts, html.InlineCode(true))
+	}
+	return html.New(opts...)
+}
+
 func NewPlugin(section *booklit.Section) booklit.Plugin {
 	return Plugin{
 		section: section,
@@ -150,12 +172,7 @@ func (plugin Plugin) syntaxHighlight(language string, code booklit.Content, chro
 		return nil, err
 	}
 
-	var formatter *html.Formatter
-	if code.IsFlow() {
-		formatter = html.New(html.InlineCode(true))
-	} else {
-		formatter = html.New()
-	}
+	formatter := highlightFormatter(code.IsFlow())
 
 	buf := new(bytes.Buffer)
 	err = formatter.Format(buf, chromaStyle, iterator)

--- a/chroma/plugin.go
+++ b/chroma/plugin.go
@@ -77,12 +77,14 @@ func (plugin Plugin) SyntaxTransform(language string, code booklit.Content, chro
 		return nil, err
 	}
 
-	var formatter *html.Formatter
-	if code.IsFlow() {
-		formatter = html.New(html.InlineCode(true))
-	} else {
-		formatter = html.New()
+	var opts []html.Option
+	if baselit.HighlightWithClasses {
+		opts = append(opts, html.WithClasses(true))
 	}
+	if code.IsFlow() {
+		opts = append(opts, html.InlineCode(true))
+	}
+	formatter := html.New(opts...)
 
 	buf := new(bytes.Buffer)
 	err = formatter.Format(buf, chromaStyle, iterator)


### PR DESCRIPTION
## Why

Syntax highlighting always emitted chroma **inline style attributes**, baking colors into the markup. That means a consuming site can't theme code from a stylesheet — most notably, code blocks can't switch palettes under `prefers-color-scheme` (inline styles aren't overridable by CSS without `!important` hacks, and per-token colors have no class hook at all).

## What

Add a package-level `baselit.HighlightWithClasses` toggle:

- **Default `false`** — unchanged inline output, so this is backward-compatible.
- **`true`** — both the `baselit` highlighter and the `chroma` plugin's `SyntaxTransform` build the formatter with `html.WithClasses(true)`, emitting chroma's CSS class names (`<span class="k">`). The caller supplies the palette via `Formatter.WriteCSS` (or a hand-written stylesheet), and can define light/dark variants.

No behavior change unless a caller opts in. `go test ./...` passes.

Used by the dang docs to give code blocks a real light-mode palette (vito/dang#96).
