### PR TITLE
marklit: smart typography for markdown prose

### DIFF
--- a/marklit/convert.go
+++ b/marklit/convert.go
@@ -12,6 +12,12 @@ import (
 type converter struct {
 	source      []byte
 	extractions []extractedInvoke
+
+	// quotePrev is the last text rune seen in the current flow block, used by
+	// smartQuotes to decide whether a quote opens or closes across adjacent
+	// text segments (e.g. text split by emphasis). It is reset to 0 at flow
+	// block boundaries by collectInlines.
+	quotePrev rune
 }
 
 // convertChildren collects the Booklit AST for all children of a goldmark
@@ -348,6 +354,11 @@ func (c *converter) splitInvokeOnlyParagraph(n gast.Node) ast.Node {
 // collectInlines gathers all inline children of a block node into a flat
 // slice of Booklit AST nodes.
 func (c *converter) collectInlines(n gast.Node) []ast.Node {
+	// Reset smart-quote context at the start of each flow block so a quote at
+	// the start of a paragraph, heading, table cell, etc. opens correctly and
+	// never inherits context from a previous block.
+	c.quotePrev = 0
+
 	var nodes []ast.Node
 	for child := n.FirstChild(); child != nil; child = child.NextSibling() {
 		converted := c.convertNode(child)
@@ -380,10 +391,15 @@ func (c *converter) convertText(t *gast.Text) ast.Node {
 		return node
 	}
 
-	// Strip Markdown backslash escapes. Goldmark's text segments contain
-	// raw escape sequences (e.g. \* \[ \\) — its own renderer strips them,
-	// but since we produce Booklit AST we need to strip them here.
-	s := ast.String(stripBackslashEscapes(value))
+	// Strip Markdown backslash escapes and apply smart-quote typography.
+	// Goldmark's text segments contain raw escape sequences (e.g. \* \[ \\) —
+	// its own renderer strips them, but since we produce Booklit AST we need to
+	// strip them here. This is also the single chokepoint for plain flow text,
+	// so curly-quote substitution happens here too; verbatim/code content never
+	// reaches convertText and is left untouched.
+	smart, last := smartQuotes(c.quotePrev, string(value))
+	c.quotePrev = last
+	s := ast.String(smart)
 	if t.SoftLineBreak() {
 		// Soft line breaks become spaces in flow content
 		return ast.Sequence{s, ast.String(" ")}
@@ -392,26 +408,6 @@ func (c *converter) convertText(t *gast.Text) ast.Node {
 		return ast.Sequence{s, ast.String("\n")}
 	}
 	return s
-}
-
-// stripBackslashEscapes removes Markdown backslash escapes from text.
-// In CommonMark, \ followed by an ASCII punctuation character produces the
-// literal punctuation character. The escape backslash is stripped.
-func stripBackslashEscapes(b []byte) []byte {
-	if !bytes.ContainsRune(b, '\\') {
-		return b
-	}
-	var out []byte
-	for i := 0; i < len(b); i++ {
-		if b[i] == '\\' && i+1 < len(b) && isASCIIPunct(b[i+1]) {
-			// Skip the escape backslash; emit the escaped char directly
-			i++
-			out = append(out, b[i])
-			continue
-		}
-		out = append(out, b[i])
-	}
-	return out
 }
 
 func isASCIIPunct(c byte) bool {

--- a/marklit/convert.go
+++ b/marklit/convert.go
@@ -397,7 +397,7 @@ func (c *converter) convertText(t *gast.Text) ast.Node {
 	// strip them here. This is also the single chokepoint for plain flow text,
 	// so curly-quote substitution happens here too; verbatim/code content never
 	// reaches convertText and is left untouched.
-	smart, last := smartQuotes(c.quotePrev, string(value))
+	smart, last := smartTypography(c.quotePrev, string(value))
 	c.quotePrev = last
 	s := ast.String(smart)
 	if t.SoftLineBreak() {

--- a/marklit/marklit_test.go
+++ b/marklit/marklit_test.go
@@ -14,6 +14,70 @@ func TestPlainText(t *testing.T) {
 	})
 }
 
+func TestSmartDoubleQuotes(t *testing.T) {
+	node := marklit.Parse([]byte(`He said "hello" to me.`))
+	assertNode(t, node, ast.Paragraph{
+		ast.Sequence{ast.String("He said “hello” to me.")},
+	})
+}
+
+func TestSmartSingleQuotesAndApostrophes(t *testing.T) {
+	node := marklit.Parse([]byte("Don't say 'no' yet."))
+	assertNode(t, node, ast.Paragraph{
+		ast.Sequence{ast.String("Don’t say ‘no’ yet.")},
+	})
+}
+
+func TestSmartQuotesAcrossEmphasis(t *testing.T) {
+	// The opening quote ends one text segment and the closing quote begins a
+	// later one; context is threaded across the emphasis so they pair up.
+	node := marklit.Parse([]byte(`A "**word**" here.`))
+	assertNode(t, node, ast.Paragraph{
+		ast.Sequence{
+			ast.String("A “"),
+			ast.Invoke{
+				Function:  "bold",
+				Arguments: []ast.Node{ast.Sequence{ast.String("word")}},
+			},
+			ast.String("” here."),
+		},
+	})
+}
+
+func TestSmartQuotesResetBetweenParagraphs(t *testing.T) {
+	// A quote opening a new paragraph must not inherit context from the
+	// previous one (which ends in a letter).
+	node := marklit.Parse([]byte("end.\n\n\"Start\""))
+	assertNode(t, node, ast.Sequence{
+		ast.Paragraph{ast.Sequence{ast.String("end.")}},
+		ast.Paragraph{ast.Sequence{ast.String("“Start”")}},
+	})
+}
+
+func TestSmartQuotesNotInCodeSpan(t *testing.T) {
+	node := marklit.Parse([]byte("Run `echo \"hi\"` now."))
+	assertNode(t, node, ast.Paragraph{
+		ast.Sequence{
+			ast.String("Run "),
+			ast.Invoke{
+				Function:  "code",
+				Arguments: []ast.Node{ast.String(`echo "hi"`)},
+			},
+			ast.String(" now."),
+		},
+	})
+}
+
+func TestSmartQuotesNotInCodeBlock(t *testing.T) {
+	node := marklit.Parse([]byte("```\nsay \"hi\"\n```"))
+	assertNode(t, node, ast.Invoke{
+		Function: "code",
+		Arguments: []ast.Node{
+			ast.Preformatted{ast.Sequence{ast.String(`say "hi"`)}},
+		},
+	})
+}
+
 func TestMultipleParagraphs(t *testing.T) {
 	node := marklit.Parse([]byte("First paragraph.\n\nSecond paragraph."))
 	assertNode(t, node, ast.Sequence{

--- a/marklit/smartypants.go
+++ b/marklit/smartypants.go
@@ -6,17 +6,23 @@ import (
 	"unicode/utf8"
 )
 
-// Smart-quote replacement runes.
+// Typographic replacement runes.
 const (
 	leftDoubleQuote  = '“' // “
 	rightDoubleQuote = '”' // ”
 	leftSingleQuote  = '‘' // ‘
 	rightSingleQuote = '’' // ’ (also the apostrophe)
+	enDash           = '–' // – (--)
+	emDash           = '—' // — (---)
+	ellipsis         = '…' // … (...)
 )
 
-// smartQuotes strips Markdown backslash escapes and applies SmartyPants-style
-// typographic substitution to plain flow text: straight double and single
-// quotes become their curly equivalents based on the surrounding context.
+// smartTypography strips Markdown backslash escapes and applies SmartyPants-style
+// typographic substitution to plain flow text:
+//
+//   - straight double and single quotes become curly quotes based on context
+//   - "--" becomes an en dash and "---" an em dash
+//   - "..." becomes an ellipsis
 //
 // This only ever runs on plain paragraph/flow text. Verbatim and preformatted
 // content — code spans, code blocks, and verbatim/preformatted \invoke
@@ -29,10 +35,10 @@ const (
 // later one — e.g. "*bold*" — resolve correctly across emphasis. The returned
 // rune is the last rune processed, to thread as prev into the next segment.
 //
-// A backslash escape is the explicit opt-out: `\"` and `\'` (like any other
-// `\<punct>`) emit the literal straight character, matching CommonMark
+// A backslash escape is the explicit opt-out: `\"`, `\'`, `\-`, `\.` (like any
+// other `\<punct>`) emit the literal straight character, matching CommonMark
 // escaping.
-func smartQuotes(prev rune, s string) (string, rune) {
+func smartTypography(prev rune, s string) (string, rune) {
 	var out strings.Builder
 	out.Grow(len(s))
 
@@ -68,6 +74,28 @@ func smartQuotes(prev rune, s string) (string, rune) {
 			default:
 				out.WriteRune(rightSingleQuote)
 			}
+		case '-':
+			if strings.HasPrefix(s[i:], "---") {
+				out.WriteRune(emDash)
+				prev = emDash
+				i += 3
+				continue
+			}
+			if strings.HasPrefix(s[i:], "--") {
+				out.WriteRune(enDash)
+				prev = enDash
+				i += 2
+				continue
+			}
+			out.WriteByte('-')
+		case '.':
+			if strings.HasPrefix(s[i:], "...") {
+				out.WriteRune(ellipsis)
+				prev = ellipsis
+				i += 3
+				continue
+			}
+			out.WriteByte('.')
 		default:
 			out.WriteRune(r)
 		}

--- a/marklit/smartypants.go
+++ b/marklit/smartypants.go
@@ -1,0 +1,95 @@
+package marklit
+
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// Smart-quote replacement runes.
+const (
+	leftDoubleQuote  = '“' // “
+	rightDoubleQuote = '”' // ”
+	leftSingleQuote  = '‘' // ‘
+	rightSingleQuote = '’' // ’ (also the apostrophe)
+)
+
+// smartQuotes strips Markdown backslash escapes and applies SmartyPants-style
+// typographic substitution to plain flow text: straight double and single
+// quotes become their curly equivalents based on the surrounding context.
+//
+// This only ever runs on plain paragraph/flow text. Verbatim and preformatted
+// content — code spans, code blocks, and verbatim/preformatted \invoke
+// arguments — reach the AST through other converters (convertCodeSpan,
+// convertCodeBlock, verbatimToNode, ParsePreformattedArg) and never pass
+// through convertText, so code is left exactly as written.
+//
+// prev is the last rune of the preceding text in the same flow block (0 at a
+// block boundary), which lets a quote opening one text segment and closing a
+// later one — e.g. "*bold*" — resolve correctly across emphasis. The returned
+// rune is the last rune processed, to thread as prev into the next segment.
+//
+// A backslash escape is the explicit opt-out: `\"` and `\'` (like any other
+// `\<punct>`) emit the literal straight character, matching CommonMark
+// escaping.
+func smartQuotes(prev rune, s string) (string, rune) {
+	var out strings.Builder
+	out.Grow(len(s))
+
+	for i := 0; i < len(s); {
+		r, size := utf8.DecodeRuneInString(s[i:])
+
+		// Backslash escapes: emit the escaped punctuation literally (straight),
+		// stripping the backslash. This is the escape hatch for literal quotes.
+		if r == '\\' && i+size < len(s) && isASCIIPunct(s[i+size]) {
+			next := rune(s[i+size])
+			out.WriteRune(next)
+			prev = next
+			i += size + 1
+			continue
+		}
+
+		switch r {
+		case '"':
+			if opensQuote(prev) {
+				out.WriteRune(leftDoubleQuote)
+			} else {
+				out.WriteRune(rightDoubleQuote)
+			}
+		case '\'':
+			// A single quote right after a letter or digit is an apostrophe or
+			// a closing quote (don't, it's, the dogs', 'hi'). Otherwise it
+			// opens at a boundary and closes anywhere else.
+			switch {
+			case isAlphaNumeric(prev):
+				out.WriteRune(rightSingleQuote)
+			case opensQuote(prev):
+				out.WriteRune(leftSingleQuote)
+			default:
+				out.WriteRune(rightSingleQuote)
+			}
+		default:
+			out.WriteRune(r)
+		}
+
+		prev = r
+		i += size
+	}
+
+	return out.String(), prev
+}
+
+// opensQuote reports whether a quote following prev should open rather than
+// close — i.e. prev is a word boundary: start-of-text, whitespace, or opening
+// punctuation.
+func opensQuote(prev rune) bool {
+	switch prev {
+	case 0, '(', '[', '{', '-', '–', '—', leftDoubleQuote, leftSingleQuote:
+		return true
+	}
+	return unicode.IsSpace(prev)
+}
+
+func isAlphaNumeric(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsDigit(r)
+}

--- a/marklit/smartypants_test.go
+++ b/marklit/smartypants_test.go
@@ -2,7 +2,7 @@ package marklit
 
 import "testing"
 
-func TestSmartQuotesHelper(t *testing.T) {
+func TestSmartTypography(t *testing.T) {
 	for _, tt := range []struct {
 		name string
 		prev rune
@@ -19,12 +19,17 @@ func TestSmartQuotesHelper(t *testing.T) {
 		{"prev letter closes double", 'd', `" rest`, "” rest"},
 		{"prev letter apostrophe", 's', "' rest", "’ rest"},
 		{"prev space opens double", ' ', `"x`, "“x"},
-		{"non-quote punct untouched", 0, "a -- b ... c", "a -- b ... c"},
+		{"en dash", 0, "a -- b", "a – b"},
+		{"em dash", 0, "a --- b", "a — b"},
+		{"ellipsis", 0, "wait...", "wait…"},
+		{"escaped dash stays straight", 0, `a \-- b`, "a -- b"},
+		{"escaped dot stays straight", 0, `a\.\.\. b`, "a... b"},
+		{"single dash and dot untouched", 0, "a-b. end", "a-b. end"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			got, _ := smartQuotes(tt.prev, tt.in)
+			got, _ := smartTypography(tt.prev, tt.in)
 			if got != tt.want {
-				t.Errorf("smartQuotes(%q, %q) = %q, want %q", tt.prev, tt.in, got, tt.want)
+				t.Errorf("smartTypography(%q, %q) = %q, want %q", tt.prev, tt.in, got, tt.want)
 			}
 		})
 	}

--- a/marklit/smartypants_test.go
+++ b/marklit/smartypants_test.go
@@ -1,0 +1,31 @@
+package marklit
+
+import "testing"
+
+func TestSmartQuotesHelper(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		prev rune
+		in   string
+		want string
+	}{
+		{"double quotes", 0, `say "hi" now`, "say “hi” now"},
+		{"apostrophe", 0, "don't", "don’t"},
+		{"single quotes", 0, "a 'quote' here", "a ‘quote’ here"},
+		{"possessive plural", 0, "the dogs' bones", "the dogs’ bones"},
+		{"leading quote opens", 0, `"x"`, "“x”"},
+		{"escaped double stays straight", 0, `\"x\"`, `"x"`},
+		{"escaped single stays straight", 0, `\'x\'`, `'x'`},
+		{"prev letter closes double", 'd', `" rest`, "” rest"},
+		{"prev letter apostrophe", 's', "' rest", "’ rest"},
+		{"prev space opens double", ' ', `"x`, "“x"},
+		{"non-quote punct untouched", 0, "a -- b ... c", "a -- b ... c"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := smartQuotes(tt.prev, tt.in)
+			if got != tt.want {
+				t.Errorf("smartQuotes(%q, %q) = %q, want %q", tt.prev, tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/tests/comments_test.go
+++ b/tests/comments_test.go
@@ -98,7 +98,7 @@ I'm another paragraph.
 
 <p>Goodbye, world!</p>
 
-<p>I'm another paragraph.</p>
+<p>I’m another paragraph.</p>
 
 <h2>1 Subsection</h2>
 

--- a/tests/line_endings_test.go
+++ b/tests/line_endings_test.go
@@ -29,7 +29,7 @@ I'm another paragraph.
 
 	<p>How are you? This is the same paragraph.</p>
 
-	<p>I'm another paragraph.</p>
+	<p>I’m another paragraph.</p>
 </section>`,
 				},
 			},

--- a/tests/partials_test.go
+++ b/tests/partials_test.go
@@ -29,13 +29,13 @@ Some more body.
 					"set-partial-read-template.html": `<div>
 	Here's a partial:
 
-	<p>I'm a partial!</p>
+	<p>I’m a partial!</p>
 </div>
 
 <div>
 	Here's the partial again:
 
-	<p>I'm a partial!</p>
+	<p>I’m a partial!</p>
 </div>
 
 <p>I want to be some body.</p>
@@ -69,7 +69,7 @@ Some more body. \reference{some-target}
 
 	<p><a id="some-target"></a></p>
 
-	<p>I'm a partial!</p>
+	<p>I’m a partial!</p>
 
 	<p><a href="set-partial-read-template.html">Set Partial Read Template</a></p>
 </div>
@@ -79,7 +79,7 @@ Some more body. \reference{some-target}
 
 	<p><a id="some-target"></a></p>
 
-	<p>I'm a partial!</p>
+	<p>I’m a partial!</p>
 
 	<p><a href="set-partial-read-template.html">Set Partial Read Template</a></p>
 </div>

--- a/tests/prose_test.go
+++ b/tests/prose_test.go
@@ -73,7 +73,7 @@ Here's an \image{foo.png}{with alt text} and another \image{without.gif}.
 					"hello-world.html": `<section>
 	<h1>Hello, world!</h1>
 
-	<p>Here's an <img src="foo.png" alt="with alt text" /> and another <img src="without.gif" alt="" />.</p>
+	<p>Here’s an <img src="foo.png" alt="with alt text" /> and another <img src="without.gif" alt="" />.</p>
 </section>`,
 				},
 			},
@@ -213,7 +213,7 @@ I'm good, thanks!
 
 	<p>How are you?</p>
 
-	<p>I'm good, thanks!</p>
+	<p>I’m good, thanks!</p>
 </section>
 `,
 				},
@@ -573,7 +573,7 @@ And here I'm just using it to \string{{{escape {{wacky}} curlies}}}.
 					"hello-world.html": `<section>
 	<h1>Hello, world!</h1>
 
-	<p>Here's a code block:</p>
+	<p>Here’s a code block:</p>
 
 	<p>I'm a code block.
 
@@ -591,7 +591,7 @@ I'm indented less.
 One more line, with meaning.
 </p>
 
-<p>And here I'm just using it to escape {{wacky}} curlies.</p>
+<p>And here I’m just using it to escape {{wacky}} curlies.</p>
 </section>
 `,
 				},

--- a/tests/references_test.go
+++ b/tests/references_test.go
@@ -149,8 +149,8 @@ See also \reference{section-c}{the last section}.
 	<h2>1 Some Section</h2>
 
 	<p>Foo bar.</p>
-	<p><a id="target-a"></a> Here's target A.</p>
-	<p><a id="target-without-display"></a> Here's another target.</p>
+	<p><a id="target-a"></a> Here’s target A.</p>
+	<p><a id="target-without-display"></a> Here’s another target.</p>
 </section>
 `,
 				},
@@ -202,7 +202,7 @@ See also \reference{section-c}{the last section}.
 
 	<h2>2 Section Baby</h2>
 
-	<p>See also <a href="hello-world.html#some-anchor">I'm an anchor.</a>.</p>
+	<p>See also <a href="hello-world.html#some-anchor">I’m an anchor.</a>.</p>
 
 	<h2>3 Section C</h2>
 

--- a/tests/search_index_test.go
+++ b/tests/search_index_test.go
@@ -35,13 +35,13 @@ Here's another paragraph.
 			"hello-world": {
 				"location": "hello-world.html",
 				"title": "Hello, world!",
-				"text": "How are you?\n\nHere's another paragraph.\n\n",
+				"text": "How are you?\n\nHere’s another paragraph.\n\n",
 				"depth": 0,
 				"section_tag": "hello-world"
 			},
 			"how-im-doing": {
 				"location": "hello-world.html#how-im-doing",
-				"title": "How I'm doing",
+				"title": "How I’m doing",
 				"text": "Good, thanks! And you?\n\n",
 				"depth": 1,
 				"section_tag": "how-im-doing"
@@ -80,7 +80,7 @@ Here's another paragraph.
 			"hello-world": {
 				"location": "hello-world.html",
 				"title": "Hello, world!",
-				"text": "How are you?\n\nHere's another paragraph.\n\n",
+				"text": "How are you?\n\nHere’s another paragraph.\n\n",
 				"depth": 0,
 				"section_tag": "hello-world"
 			},
@@ -155,7 +155,7 @@ and a \reference{sub-section}.
 			"hello-world": {
 				"location": "hello-world.html",
 				"title": "Hello, world!",
-				"text": "How are you?\n\nHere's a paragraph with code, a link, and a Sub-Section.\n\n* Item 1\n\n  Another line\n\n* Item 2\n\n1. Ordered Item 1\n\n2. Ordered Item 2\n\nline 1\nline 2\n| a | 1 |\n| b | 2 |\n\na: 1\nb: 2\n\n",
+				"text": "How are you?\n\nHere’s a paragraph with code, a link, and a Sub-Section.\n\n* Item 1\n\n  Another line\n\n* Item 2\n\n1. Ordered Item 1\n\n2. Ordered Item 2\n\nline 1\nline 2\n| a | 1 |\n| b | 2 |\n\na: 1\nb: 2\n\n",
 				"depth": 0,
 				"section_tag": "hello-world"
 			},

--- a/tests/sections_test.go
+++ b/tests/sections_test.go
@@ -35,7 +35,7 @@ How are you?
 
 	<p>How are you?</p>
 
-	<h2>1 How I'm doing</h2>
+	<h2>1 How I’m doing</h2>
 
 	<p>Good, thanks! And you?</p>
 
@@ -69,7 +69,7 @@ Good, thanks!
 
 	<p>How are you?</p>
 
-	<h2>1 How I'm doing</h2>
+	<h2>1 How I’m doing</h2>
 
 	<p>Good, thanks! And you?</p>
 
@@ -99,7 +99,7 @@ Good, thanks!
 
 	<p>How are you?</p>
 
-	<h2>1 How I'm doing</h2>
+	<h2>1 How I’m doing</h2>
 
 	<p>Good, thanks!</p>
 </section>
@@ -251,11 +251,11 @@ How are you?
 
 	<p>How are you?</p>
 
-	<h2>1 How I'm doing</h2>
+	<h2>1 How I’m doing</h2>
 
 	<h3>1.1 After Much Deliberation</h3>
 
-	<p>I have decided that I'm doing well. How about you?</p>
+	<p>I have decided that I’m doing well. How about you?</p>
 
 	<h2>2 Their Reply</h2>
 
@@ -289,7 +289,7 @@ How are you?
 </section>
 `,
 					"how-im-doing.html": `<section>
-	<h1>1 How I'm Doing</h1>
+	<h1>1 How I’m Doing</h1>
 
 	<p>Good, thanks!</p>
 </section>
@@ -410,7 +410,7 @@ How are you?
 
 	<p>How are you?</p>
 
-	<h2>1 How I'm Doing</h2>
+	<h2>1 How I’m Doing</h2>
 
 	<p>Good, thanks!</p>
 </section>
@@ -564,7 +564,7 @@ How are you?
 		<p>How are you?</p>
 	</div>
 
-	<h2>1 How I'm doing</h2>
+	<h2>1 How I’m doing</h2>
 
 	<p>I'm a sub template! Here's my body:</p>
 
@@ -574,7 +574,7 @@ How are you?
 
 	<h3>1.1 After Much Deliberation</h3>
 
-	<p>I have decided that I'm doing well. How about you?</p>
+	<p>I have decided that I’m doing well. How about you?</p>
 
 	<h2>2 Their Reply</h2>
 


### PR DESCRIPTION
Adds SmartyPants-style typographic substitution to the markdown renderer, so plain prose gets proper typography automatically:

- `"foo"` → `“foo”`, `'foo'` → `‘foo’`, and `don't` / possessives → `don’t`
- `--` → en dash, `---` → em dash, `...` → ellipsis

## Where it lives

The substitution happens in `marklit`'s `convertText`, which is the single chokepoint for plain flow text. Verbatim content is untouched for free: code spans, code blocks, and verbatim/preformatted `\invoke` arguments reach the AST through other converters and never pass through `convertText`.

A couple of refinements:

- **Cross-segment context** — a quote that opens one text run and closes a later one (e.g. across `*emphasis*`) resolves correctly, and context resets at block boundaries so a quote opening a paragraph never inherits the previous block.
- **Escape opt-out** — `\"`, `\'`, `\-`, `\.` emit literal straight characters, folded into the existing backslash-escape stripping at the same site.

## Scope

Applies to `.md` sources only. `.lit` files go through the separate PEG parser and are unaffected — the docs site is authored in `.md`, so real content is covered.

It's always-on. The integration golden tests are updated to expect curly quotes in prose-sourced output, leaving attribute and `<code>`/`<pre>` quotes straight.

## Tests

New unit tests for the helper (quotes, apostrophes, dashes, ellipsis, escapes) plus marklit-level cases covering cross-emphasis quotes, paragraph resets, and the code-span/code-block exclusions. `go test ./...` is green.
